### PR TITLE
Weechat exec tweak

### DIFF
--- a/weechat/README.md
+++ b/weechat/README.md
@@ -7,7 +7,7 @@ This is an automatically built Alpine Docker image for Weechat. It will rebuild 
 
 To run it simply use ```docker run```:
 
-``` docker run -it --tty --name weechat -e UID=1000 -e GID=1000 -v /path/to/weechat/config:/weechat jkaberg/weechat```
+``` docker run -it --name weechat -e UID=1000 -e GID=1000 -v /path/to/weechat/config:/weechat jkaberg/weechat```
 
 or docker-compose:
 ```

--- a/weechat/README.md
+++ b/weechat/README.md
@@ -14,6 +14,7 @@ or docker-compose:
   weechat:
     image: jkaberg/weechat
     restart: always
+    stdin_open: true
     tty: true
     volumes:
       - /path/to/weechat/config:/weechat

--- a/weechat/run.sh
+++ b/weechat/run.sh
@@ -5,4 +5,4 @@ groupmod -o -g "$UID" weechat
 
 chown -R weechat:weechat /weechat
 
-su-exec weechat /usr/bin/weechat "$@"
+exec su-exec weechat /usr/bin/weechat "$@"


### PR DESCRIPTION
Hi,

Thanks for the weechat docker image.

This is a small tweak to the `run.sh` script that allow signals to be passed from docker to weechat, which means that the container can cleanly shutdown (doesn't wait for 10 second timeout before killing it, cleanly disconnects and saves config, etc).

Also added `stdin_open: true` to the docker-compose notes, which lets you detach (`ctrl-p`, `ctrl-q`) and reattach (`docker attach weechat`) to weechat when running it that way.