### PR TITLE
keep gettext package after compilation so weechat starts

### DIFF
--- a/weechat/Dockerfile
+++ b/weechat/Dockerfile
@@ -29,6 +29,7 @@ RUN BUILD_DEPS=" \
     tar" \
     && apk -U upgrade && apk add \
     ${BUILD_DEPS} \
+    gettext \
     gnutls \
     ncurses \
     libgcrypt \


### PR DESCRIPTION
I had to add the gettext package to the list of persistent installations because weechat was failing to start at all, complaining:

    usermod: no changes
    Error loading shared library libintl.so.8: No such file or directory (needed by /usr/bin/weechat)
    Error relocating /usr/bin/weechat: libintl_bindtextdomain: symbol not found
    Error relocating /usr/bin/weechat: libintl_bind_textdomain_codeset: symbol not found
    Error relocating /usr/bin/weechat: libintl_ngettext: symbol not found
    Error relocating /usr/bin/weechat: libintl_textdomain: symbol not found
    Error relocating /usr/bin/weechat: libintl_gettext: symbol not found

with this change, weechat seems to start up properly.